### PR TITLE
Improve editors titles and display names - images selection

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,6 +3,11 @@ import Editor from "./Editor";
 import useLocalStorage from "../hooks/useLocalStorage";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRedo } from "@fortawesome/free-solid-svg-icons";
+import {
+  CSS_DISPLAY_NAME,
+  HTML_DISPLAY_NAME,
+  JS_DISPLAY_NAME,
+} from "../constants/displayNames";
 
 function App() {
   const [html, setHtml] = useLocalStorage("html");
@@ -51,19 +56,19 @@ function App() {
       <div className="pane top-pane">
         <Editor
           language="xml"
-          displayName="HTML"
+          displayName={HTML_DISPLAY_NAME}
           value={html}
           onChange={setHtml}
         />
         <Editor
           language="css"
-          displayName="CSS"
+          displayName={CSS_DISPLAY_NAME}
           value={css}
           onChange={setCss}
         />
         <Editor
           language="javascript"
-          displayName="JS"
+          displayName={JS_DISPLAY_NAME}
           value={js}
           onChange={setJs}
         />

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -7,20 +7,11 @@ import "codemirror/mode/css/css";
 import { Controlled as ControlledEditor } from "react-codemirror2";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCompressAlt, faExpandAlt } from "@fortawesome/free-solid-svg-icons";
+import { DISPLAY_NAMES_IMAGES } from "../constants/displayNamesImages";
 
 function Editor(props) {
   const { displayName, language, value, onChange } = props;
-  let imgName = "";
-
-  if (displayName === "HTML") {
-    imgName = "248-mega.png";
-  }
-  if (displayName === "JS") {
-    imgName = "208-mega.png";
-  }
-  if (displayName === "CSS") {
-    imgName = "094-mega.png";
-  }
+  let imgName = DISPLAY_NAMES_IMAGES[displayName] || "";
 
   const [open, setOpen] = useState(true);
 

--- a/src/constants/displayNames.js
+++ b/src/constants/displayNames.js
@@ -1,0 +1,5 @@
+export const HTML_DISPLAY_NAME = "HTML";
+
+export const CSS_DISPLAY_NAME = "CSS";
+
+export const JS_DISPLAY_NAME = "JS";

--- a/src/constants/displayNamesImages.js
+++ b/src/constants/displayNamesImages.js
@@ -1,0 +1,11 @@
+import {
+  CSS_DISPLAY_NAME,
+  HTML_DISPLAY_NAME,
+  JS_DISPLAY_NAME,
+} from "./displayNames";
+
+export const DISPLAY_NAMES_IMAGES = {
+  [HTML_DISPLAY_NAME]: "248-mega.png",
+  [CSS_DISPLAY_NAME]: "208-mega.png",
+  [JS_DISPLAY_NAME]: "094-mega.png",
+};

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,8 @@ body {
 .editor-title {
     display: flex;
     justify-content: space-between;
+    font-size: 1.2em;
+    align-items: center;
     background-color: hsl(225, 6%, 13%);
     color: white;
     padding: .5rem .5rem .5rem 1rem;


### PR DESCRIPTION
* Improve editors titles
![Screenshot 2020-10-04 at 17 47 55](https://user-images.githubusercontent.com/19331093/95020146-be5c8800-0669-11eb-90c8-36f84bb95cac.png)
* Improve code for editor header images
